### PR TITLE
Build with optimizations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC := arm-linux-gnueabihf-gcc
 LD := $(CC)
-CFLAGS := -std=gnu99 -g
+CFLAGS := -std=gnu99 -Wall -O1 -mfloat-abi=hard -march=armv7-a -mtune=cortex-a9 -mfpu=neon
 LDFLAGS := $(CFLAGS)
 
 OBJS := main.o resolve.o syscalls.o


### PR DESCRIPTION
Build it more like what VitaSDK does, optimizing for the Vita's CPU. `-O1` is the maximum optimization that doesn't crash, for some reason. The other parameters are the ones used by VitaSDK for their build of GCC.

This is a small piece of code, but removing the `-g` parameter and bringing it more in line with the rest of the things built can be benefitial.